### PR TITLE
Center first page content vertically

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,8 +70,8 @@ export default function Home() {
   return (
     <motion.div initial="hidden" animate="visible" variants={container}>
       <Image src="/opengraph-image.png" alt="site preview image" width={0} height={0} />
-      <div className="min-h-screen flex items-start md:items-center pt-16 md:pt-0">
-        <div className="w-full px-4 md:px-0 md:ml-[10%] lg:ml-[20%] mt-8 md:-mt-10">
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="w-full px-4 md:px-0 md:ml-[10%] lg:ml-[20%]">
           <motion.h1 variants={itemUp} className="text-4xl md:text-5xl lg:text-6xl font-crimson-pro mb-4 text-center md:text-left">
             hey, i&apos;m hanz.
           </motion.h1>


### PR DESCRIPTION
Vertically center the first page content by adjusting flex alignment and removing excessive top spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-e29fd126-d747-45d4-a681-3d9323834c6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e29fd126-d747-45d4-a681-3d9323834c6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

