### PR TITLE
Remove resume link from social links

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -232,7 +232,6 @@ const description =
     <div class="social-content">
       <h2 class="social-title animate-item">find me here:</h2>
       <div class="social-links">
-        <a href="https://resume.hanzpo.com/resume.pdf" class="social-link animate-item" target="_blank" rel="noopener noreferrer">resume</a>
         <a href="https://www.github.com/HanzPo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">github</a>
         <a href="https://www.linkedin.com/in/hanznathanpo/" class="social-link animate-item" target="_blank" rel="noopener noreferrer">linkedin</a>
         <a href="https://x.com/hanznathanpo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">twitter</a>


### PR DESCRIPTION
## Summary

Removes the **resume** link (`https://resume.hanzpo.com/resume.pdf`) from the "find me here" social links section on the homepage.

## Changes

- Deleted the resume `<a>` from `src/pages/index.astro`. GitHub, LinkedIn, Twitter, Instagram, and the CS Webring are unchanged.

## Verification

- `npm run build` passes.
- Confirmed no other references to the resume link remain in `src/` or `public/`.