### PR TITLE
Update Twitter link to x.com/hanzpo

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -149,7 +149,7 @@ const description =
       "sameAs": [
         "https://github.com/HanzPo",
         "https://www.linkedin.com/in/hanznathanpo/",
-        "https://x.com/hanznathanpo",
+        "https://x.com/hanzpo",
         "https://www.instagram.com/hanznathanpo"
       ]
     })} />
@@ -235,7 +235,7 @@ const description =
         <a href="https://resume.hanzpo.com/resume.pdf" class="social-link animate-item" target="_blank" rel="noopener noreferrer">resume</a>
         <a href="https://www.github.com/HanzPo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">github</a>
         <a href="https://www.linkedin.com/in/hanznathanpo/" class="social-link animate-item" target="_blank" rel="noopener noreferrer">linkedin</a>
-        <a href="https://x.com/hanznathanpo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">twitter</a>
+        <a href="https://x.com/hanzpo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">twitter</a>
         <a href="https://www.instagram.com/hanznathanpo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">instagram</a>
         <div class="webring animate-item">
           <a href="https://cs.uwatering.com/#https://hanzpo.com?nav=prev" aria-label="Previous site in CS Webring">←</a>


### PR DESCRIPTION
## Summary

Updates the Twitter handle from `hanznathanpo` to `hanzpo`.

## Changes

- Twitter button `href` → `https://x.com/hanzpo` in `src/pages/index.astro`
- Matching `sameAs` entry in the JSON-LD structured data updated to keep it consistent

LinkedIn and Instagram handles are unchanged.

## Verification

- `npm run build` passes.
- Confirmed both `x.com` references now point to `hanzpo`.