### PR TITLE
Revert Twitter link back to x.com/hanznathanpo

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -149,7 +149,7 @@ const description =
       "sameAs": [
         "https://github.com/HanzPo",
         "https://www.linkedin.com/in/hanznathanpo/",
-        "https://x.com/hanzpo",
+        "https://x.com/hanznathanpo",
         "https://www.instagram.com/hanznathanpo"
       ]
     })} />
@@ -234,7 +234,7 @@ const description =
       <div class="social-links">
         <a href="https://www.github.com/HanzPo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">github</a>
         <a href="https://www.linkedin.com/in/hanznathanpo/" class="social-link animate-item" target="_blank" rel="noopener noreferrer">linkedin</a>
-        <a href="https://x.com/hanzpo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">twitter</a>
+        <a href="https://x.com/hanznathanpo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">twitter</a>
         <a href="https://www.instagram.com/hanznathanpo" class="social-link animate-item" target="_blank" rel="noopener noreferrer">instagram</a>
         <div class="webring animate-item">
           <a href="https://cs.uwatering.com/#https://hanzpo.com?nav=prev" aria-label="Previous site in CS Webring">←</a>


### PR DESCRIPTION
## Summary

Reverts the Twitter handle from `hanzpo` back to `hanznathanpo` (the `hanzpo` vanity handle is tied to Twitter Premium, which is expiring).

## Changes

- Twitter button `href` → `https://x.com/hanznathanpo` in `src/pages/index.astro`
- Matching `sameAs` entry in the JSON-LD structured data reverted to match

LinkedIn and Instagram handles are unchanged.

## Verification

- `npm run build` passes.
- Confirmed both `x.com` references point to `hanznathanpo`.